### PR TITLE
Disable Ruby built-in documentation

### DIFF
--- a/install_ruby2-1-2.sh
+++ b/install_ruby2-1-2.sh
@@ -5,10 +5,10 @@ rm -rf ruby-installer
 mkdir ruby-installer
 cd ruby-installer
 echo "fetch latest ruby from ftp.ruby-lang.org"
-wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz
+wget -nv http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz
 tar -xzvf ruby-2.1.2.tar.gz
 echo "installing ruby 2.1.2"
-cd ruby-2.1.2/ && ./configure && make && make install
+cd ruby-2.1.2/ && ./configure --disable-install-doc && make && make install
 echo "installed ruby interpreter, version:"
 echo `ruby -v`
 gem install bundler --no-ri --no-rdoc


### PR DESCRIPTION
We should not need this during automated builds and it speeds up installation considerably

Also disabled wget progress bar to clean up logs

Signed-off-by: Adam Stegman astegman@pivotal.io
